### PR TITLE
Change Building Outline Color - CMS tab

### DIFF
--- a/docs/03-Map/01-Map Styling/change-building-outline-color.mdx
+++ b/docs/03-Map/01-Map Styling/change-building-outline-color.mdx
@@ -1,9 +1,9 @@
 ---
-title: Change Building Outline Color
+title: Change Building Outline
 hide_title: false
 hide_table_of_contents: true
 sidebar_position: 4
-slug: /change-building-outline-color
+slug: /change-building-outline
 ---
 
 import Tabs from '@theme/Tabs';
@@ -77,17 +77,51 @@ The sample uses the example `UIColor.red`, but this can be any standard color su
 </TabItem>
 <TabItem value="web" label="Web v4">
 
-To change the building outline color, use the `strokeColor` property of the `BuildingOutlineOptions` interface. This property accepts any color as defined by conventional CSS color values. See [https://developer.mozilla.org/en-US/docs/Web/CSS/color_value](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value) for more information on CSS color values.
+The building outline design will be taken from the values set through the CMS. To change the building outline you can use the different properties of the `BuildingOutlineOptions` interface. The properties are the following:
 
-To do this in practice, on the MapsIndoors instance, call `setBuildingOutlineOptions` to change the appearance of the building outline.
+1. `visible` - Controls whether the Building Outline is visible on the map.
+    * The value should be a Boolean here, so either `true` or `false`.
+1. `zoomFrom` - Sets the minimum Zoom Level at which the Building Outline is visible.
+    * The value should be a number between 1 and 25, with 1 being very far away, and 25 being very close (25 not available for all Solutions). In a general use case, most users will only need values between 15 and 25.
+1. `zoomTo`- Sets the maximum Zoom Level at which the Building Outline is visible.
+    * The value should be a number between 1 and 25, with 1 being very far away, and 25 being very close (25 not available for all Solutions). In a general use case, most users will only need values between 15 and 25.
+1. `strokeColor` - Controls the stroke color of the Building Outline.
+    * This property accepts any color as defined by conventional CSS color values. See [https://developer.mozilla.org/en-US/docs/Web/CSS/color_value](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value) for more information on CSS color values.
+1. `strokeWeight` - Controls the stroke width (in pixels) of the Building Outline.
+    * The value should be a number between.
+1. `strokeOpacity` - Controls the stroke opacity of the Building Outline.
+    * The value should be a number between 0 and 1, for example a value of 1 gives 100% opacity, 0.2 gives 20% opacity, etc.
+
+To read more about the `BuildingOutlineOptions` interface see the [reference docs](https://app.mapsindoors.com/mapsindoors/js/sdk/latest/docs/BuildingOutlineOptions.html).
+
+One way to do this in practice, call `setBuildingOutlineOptions` on the MapsIndoors instance, to change the appearance of the building outline.
 
 ```javascript
-mapsIndoors.setBuildingOutlineOptions({strokeColor: '#3071d9'});
+mapsIndoors.setBuildingOutlineOptions({
+    visible: true,
+    zoomFrom: 15,
+    zoomTo: 20,
+    strokeColor: '#fcd305',
+    strokeWeight: 5,
+    strokeOpacity: 0.8
+});
 ```
 
-Additional variables such as `strokeWeight` (for the thickness of the stroke) can also be used here, see the [reference docs](https://app.mapsindoors.com/mapsindoors/js/sdk/latest/docs/BuildingOutlineOptions.html) for the full list.
+Alternatively, you can define the `buildingOutlineOptions` property when creating a new mapsindoors instance.
 
-You can also modify the fill color of a building, not just the outline. This is done using Display Rules, and more can be read about that [here](/display-rules#polygon).
+```javascript
+new mapsindoors.MapsIndoors({
+    mapView: mapView,
+    buildingOutlineOptions: {
+        visible: true,
+        zoomFrom: 15,
+        zoomTo: 20,
+        strokeColor: '#fcd305',
+        strokeWeight: 5,
+        strokeOpacity: 0.8
+    }
+});
+```
 
 </TabItem>
 </Tabs>

--- a/docs/03-Map/01-Map Styling/change-building-outline-color.mdx
+++ b/docs/03-Map/01-Map Styling/change-building-outline-color.mdx
@@ -14,7 +14,28 @@ One way you can alter the look and feel of your map is by changing the color of 
 The method to do this is different for each platform.
 
 <Tabs groupId="display-rules">
-<TabItem value="android" label="Android v4" default>
+<TabItem value="cms" label="CMS" default>
+
+In the CMS, you can edit the Building Outline Display Rules by navigating to `Solution Details` -> `Building Highlight`. Here you will find the "Polygon" section that contains options related to the appearance of the Building Outline. You see your setting by navigating to `Map`.
+
+1. **Visibility** - Controls whether the Building Outline is visible on the map.
+    * The system will accept a Boolean here, so either `true` or `false`.
+1. **Zoom from** - Sets the minimum Zoom Level at which the Building Outline is visible.
+    * The value should be a number between 1 and 25, with 1 being very far away, and 25 being very close (25 not available for all Solutions). In a general use case, most users will only need values between 15 and 25.
+    * If you are developing using the JavaScript SDK for Google Maps, the value must be an integer. If you are developing for Android or iOS, or using a different map provider, the value may be fractional.
+1. **Zoom to** - Sets the maximum Zoom Level at which the Building Outline is visible.
+    * The value should be a number between 1 and 25, with 1 being very far away, and 25 being very close (25 not available for all Solutions). In a general use case, most users will only need values between 15 and 25.
+    * Checking the `Max zoom` checkbox will ensure that the Building Outline will be visible at the largest possible Zoom level (this value may increase in the future).
+    * If you are developing using the JavaScript SDK for Google Maps, the value must be an integer. If you are developing for Android or iOS, or using a different map provider, the value may be fractional.
+1. **Stroke color** - Controls the stroke color of the Building Outline.
+    * In the CMS, you can select a color using the color picker displayed when clicking the color input field.
+    * If setting the color in-app, the value provided must be in 6-digit HEX code (eg. #3071D9).
+1. **Stroke width** - Controls the stroke width (in pixels) of the Building Outline.
+1. **Stroke opacity** - Controls the stroke opacity of the Building Outline.
+    * The value here should be between 0 and 1, for example a value of 1 gives 100% opacity, 0.2 gives 20% opacity, etc.
+
+</TabItem>
+<TabItem value="android" label="Android v4">
 
 :::info
 


### PR DESCRIPTION
I added a new tab for how to set the Building Outline settings via the CMS.

I did not update the Web SDK tab because I think it fits with the new implementation as well.