### PR TITLE
fix: Building Outline - CMS path

### DIFF
--- a/docs/03-Map/01-Map Styling/change-building-outline-color.mdx
+++ b/docs/03-Map/01-Map Styling/change-building-outline-color.mdx
@@ -16,7 +16,7 @@ The method to do this is different for each platform.
 <Tabs groupId="display-rules">
 <TabItem value="cms" label="CMS" default>
 
-In the CMS, you can edit the Building Outline Display Rules by navigating to `Solution Details` -> `Building Highlight`. Here you will find the "Polygon" section that contains options related to the appearance of the Building Outline. You see your setting by navigating to `Map`.
+In the CMS, you can edit the Building Outline Display Rules by navigating to `Solution Details` -> `Solution Settings` -> `Building Highlight`. Here you will find the "Polygon" section that contains options related to the appearance of the Building Outline. You see your setting by navigating to `Map`.
 
 1. **Visibility** - Controls whether the Building Outline is visible on the map.
     * The system will accept a Boolean here, so either `true` or `false`.


### PR DESCRIPTION
We got the bug report that under the CMS tab (for the Building Outline) the path is not correct.