### PR TITLE
expanded building outline display rule notes for android/ios

### DIFF
--- a/docs/03-Map/01-Map Styling/change-building-outline-color.mdx
+++ b/docs/03-Map/01-Map Styling/change-building-outline-color.mdx
@@ -53,6 +53,8 @@ MapsIndoors.getDisplayRule(MPSolutionDisplayRule.BUILDING_OUTLINE).setPolygonStr
 
 The parameter `strokeColor` takes the color in ARGB format (with an alpha-channel value), the syntax being `AARRGGBB`.
 
+Note that only the polygon stroke color, width, opacity, visible, zoomFrom and zoomTo values are respected.
+
 </TabItem>
 <TabItem value="ios-v4" label="iOS v4">
 
@@ -62,7 +64,7 @@ To change the building outline color, along with other display properties, you m
 let buildingOutline = MPMapsIndoors.shared.displayRuleFor(displayRuleType: .buildingOutline)
 buildingOutline?.polygonStrokeColor = .blue
 ```
-Note that only the polygon stroke color, width and opacity values are respected.
+Note that only the polygon stroke color, width, opacity, visible, zoomFrom and zoomTo values are respected.
 
 </TabItem>
 <TabItem value="ios-v3" label="iOS v3">


### PR DESCRIPTION
Forgot the zoom interval - and might as well add the same note for Android